### PR TITLE
Update cookie retrieval in server client

### DIFF
--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { Database } from '@/types/database.types'
 
 export async function createServerSupabaseClient() {
-  const cookieStore = await cookies()
+  const cookieStore = cookies()
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- remove unnecessary `await` when getting cookies in the server-side Supabase client

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472f25a6788326a99e5b30d7d107bc