### PR TITLE
Add login and register placeholder pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,7 @@
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      Login page coming soon
+    </div>
+  );
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,7 @@
+export default function RegisterPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      Register page coming soon
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `app/login/page.tsx` and `app/register/page.tsx` with simple placeholders
- navigation in `app/page.tsx` already links to `/login` and `/register`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472f28bde88326a93644ff42ba5944