### PR TITLE
Fix trailing shell prompt in CONFIGURATION.md

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -229,4 +229,4 @@ W Vercel Dashboard dodaj wszystkie zmienne środowiskowe z pliku `.env.local`
 
 ### Problem: "Build Error"
 - Sprawdź czy wszystkie wymagane zmienne środowiskowe są ustawione
-- Uruchom `npm run build` lokalnie aby zidentyfikować błędy 
+- Uruchom `npm run build` lokalnie aby zidentyfikować błędy


### PR DESCRIPTION
## Summary
- remove extraneous prompt text from the last line of `CONFIGURATION.md`
- ensure newline at end of file

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472f56799c8326895211288aef3947