### PR TITLE
Add Jest setup and basic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Aplikacja jest w pełni responsywna i zoptymalizowana dla:
 
 ## 🧪 Testowanie
 
+Testy jednostkowe uruchomisz komendą:
+
 ```bash
 # Testy jednostkowe
 npm run test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).ts'],
+};

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,18 @@
+import { formatCurrency } from './utils'
+
+describe('formatCurrency', () => {
+  it('returns formatted currency for a number', () => {
+    const value = 12345
+    const expected = new Intl.NumberFormat('pl-PL', {
+      style: 'currency',
+      currency: 'PLN',
+    }).format(value)
+    expect(formatCurrency(value)).toBe(expected)
+  })
+
+  it('returns 0 zł for nullish values', () => {
+    expect(formatCurrency(0)).toBe('0 zł')
+    expect(formatCurrency(null)).toBe('0 zł')
+    expect(formatCurrency(undefined)).toBe('0 zł')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -35,6 +36,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest
- add first unit tests for `formatCurrency`
- document running tests in README

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472f29d6c88326a79dd0b4be60a187