### PR TITLE
Add Vitest setup and utility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Aplikacja jest w pełni responsywna i zoptymalizowana dla:
 ## 🧪 Testowanie
 
 ```bash
-# Testy jednostkowe
+# Testy jednostkowe (Vitest)
 npm run test
 
 # Testy integracyjne

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { formatCurrency, formatDate, formatDateTime, getInitials, slugify } from './utils'
+
+describe('utils', () => {
+  it('formatCurrency returns "0 zł" for falsy values', () => {
+    expect(formatCurrency(null)).toBe('0 zł')
+    expect(formatCurrency(undefined)).toBe('0 zł')
+    expect(formatCurrency(0)).toBe('0 zł')
+  })
+
+  it('formatCurrency formats numbers to PLN', () => {
+    expect(formatCurrency(1234.56)).toBe('1234,56\u00A0zł')
+  })
+
+  it('formatDate formats a date string', () => {
+    expect(formatDate('2024-01-05')).toBe('5 stycznia 2024')
+  })
+
+  it('formatDateTime formats a date and time string', () => {
+    expect(formatDateTime('2024-01-05T15:45:00')).toBe('5 sty 2024, 15:45')
+  })
+
+  it('getInitials returns the first two initials', () => {
+    expect(getInitials('Jan Kowalski')).toBe('JK')
+  })
+
+  it('slugify converts text to a slug', () => {
+    expect(slugify('Hello World!')).toBe('hello-world')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -35,6 +36,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- set up basic Vitest configuration with TypeScript
- add unit tests for utility helpers
- expose `npm run test` script
- document testing in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472f5bba088326a6ba967c551c8449